### PR TITLE
VCF output badly formatted?

### DIFF
--- a/src/vcf.c
+++ b/src/vcf.c
@@ -111,10 +111,10 @@ void output_vcf_row(FILE * vcf_file_pointer, char * bases_for_snp, int snp_locat
 	fprintf( vcf_file_pointer, ".\t");
 	
 	// FORMAT
-	fprintf( vcf_file_pointer, "AB\t");
+	fprintf( vcf_file_pointer, "GT\t");
 	
 	// Bases for each sample
-	output_vcf_row_samples_bases(vcf_file_pointer, reference_base, bases_for_snp, number_of_samples,internal_nodes );
+	output_vcf_row_samples_bases(vcf_file_pointer, reference_base, alt_bases, bases_for_snp, number_of_samples,internal_nodes );
 	
 	fprintf( vcf_file_pointer, "\n");	
 }
@@ -160,7 +160,23 @@ int check_if_char_in_string(char search_string[], char target_char, int search_s
 	return 0;
 }
 
-void output_vcf_row_samples_bases(FILE * vcf_file_pointer, char reference_base, char * bases_for_snp, int number_of_samples,int internal_nodes[])
+// One indexed. String must be null terminated
+int check_where_char_in_string(char search_string[], char target_char)
+{
+	int i;
+	while(search_string[i] != '\0')
+	{
+		if(search_string[i] == target_char)
+		{
+			return i+1;
+		}
+      i++;
+	}
+	return 0;
+}
+
+
+void output_vcf_row_samples_bases(FILE * vcf_file_pointer, char reference_base, char alt_bases[], char * bases_for_snp, int number_of_samples,int internal_nodes[])
 {
 	int i;
 	
@@ -172,11 +188,12 @@ void output_vcf_row_samples_bases(FILE * vcf_file_pointer, char reference_base, 
 		}
 		if(bases_for_snp[i] == reference_base)
 		{
-			fprintf( vcf_file_pointer, "%c", (char) reference_base );	
+			fprintf( vcf_file_pointer, "%c", (char) '0' );	
 		}
 		else
 		{
-			fprintf( vcf_file_pointer, "%c", (char) bases_for_snp[i] );	
+			int alt_base_idx = check_where_char_in_string(alt_bases, bases_for_snp[i]) - 1;
+         fprintf( vcf_file_pointer, "%c", (char) alt_bases[alt_base_idx] );	
 		}
 		if(i+1 != number_of_samples)
 		{

--- a/src/vcf.c
+++ b/src/vcf.c
@@ -188,12 +188,11 @@ void output_vcf_row_samples_bases(FILE * vcf_file_pointer, char reference_base, 
 		}
 		if(bases_for_snp[i] == reference_base)
 		{
-			fprintf( vcf_file_pointer, "%c", (char) '0' );	
+			fprintf( vcf_file_pointer, "%c", (char) '0' );
 		}
 		else
 		{
-			int alt_base_idx = check_where_char_in_string(alt_bases, bases_for_snp[i]) - 1;
-         fprintf( vcf_file_pointer, "%c", (char) alt_bases[alt_base_idx] );	
+         fprintf( vcf_file_pointer, "%c", (char) check_where_char_in_string(alt_bases, bases_for_snp[i]));
 		}
 		if(i+1 != number_of_samples)
 		{

--- a/src/vcf.h
+++ b/src/vcf.h
@@ -24,9 +24,10 @@ void output_vcf_header( FILE * vcf_file_pointer, char ** sequence_names, int num
 void create_vcf_file(char filename[], int snp_locations[], int number_of_snps, char ** bases_for_snps, char ** sequence_names, int number_of_samples,int internal_nodes[], int offset, int length_of_original_genome);
 void output_vcf_snps(FILE * vcf_file_pointer, char ** bases_for_snps, int * snp_locations, int number_of_snps, int number_of_samples,int internal_nodes[], int offset);
 void output_vcf_row(FILE * vcf_file_pointer, char * bases_for_snp, int snp_location, int number_of_samples,int internal_nodes[], int offset);
-void output_vcf_row_samples_bases(FILE * vcf_file_pointer, char reference_base, char * bases_for_snp, int number_of_samples,int internal_nodes[]);
+void output_vcf_row_samples_bases(FILE * vcf_file_pointer, char reference_base, char alt_bases[], char * bases_for_snp, int number_of_samples,int internal_nodes[]);
 void alternative_bases(char reference_base, char * bases_for_snp, char alt_bases[], int number_of_samples);
 int check_if_char_in_string(char search_string[], char target_char, int search_string_length);
+int check_where_char_in_string(char search_string[], char target_char);
 
 
 #endif


### PR DESCRIPTION
I think the vcfs produced are in a non-ideal format. Reading them in Artemis leads to all samples being shown as positive for the SNP. 

I believe a more common format is to have the fields as genotypes, with an index per sample corresponding to the base (0 for ref, 1 for alt-0, 2 for alt-1 etc). This is as in http://samtools.github.io/hts-specs/VCFv4.2.pdf

I think this is written in output_vcf_row_samples_bases of [vcf.c](https://github.com/sanger-pathogens/gubbins/blob/fe094b079c8d47408846884208f98999702776af/src/vcf.c#L173-L180). Changing the AB to a GT, and these lines to 0 and 1 instead of the bases I think would fix this. I think this pull request does this, but I haven't tested it as I don't have a working test build of gubbins (the changes pass compilation though)
