### PR TITLE
Link check to lsubunit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
     - check
     - g++
     - libtool
+    - libsubunit-dev
     - pkg-config
     - python3-dev
     - python3-setuptools

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -43,6 +43,7 @@ else
                              check \
                              g++ \
                              libtool \
+                             libsubunit-dev \
                              pkg-config \
                              python-dev
 fi

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -33,5 +33,5 @@ run_all_tests_CFLAGS = -I../tests $(PTHREAD_CFLAGS)
 run_all_tests_LDADD = -lcheck libgubbins.la -lz -lm $(PTHREAD_LDFLAGS)
 
 if HOST_LINUX
-run_all_tests_LDADD += -lrt
+run_all_tests_LDADD += -lrt -lsubunit
 endif


### PR DESCRIPTION
libcheck has a dependency on libsubunit on newer linux systems (Ubuntu 16.04, Debian 9) - see also [here](https://github.com/libcheck/check/issues/60)

solved by linking to `-lsubunit` and making sure the package is installed, also on Travis.
Note: might be related to a similar issue with [snp-sites](https://github.com/sanger-pathogens/snp-sites/issues/33)