### PR TITLE
Rename exec in docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
   - "build"
   - "$HOME/.cache/pip"
 python:
-  - "3.4"
+  - "3.5"
 sudo: false
 install:
   - "source ./install_dependencies.sh"

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,3 @@ RUN git clone https://github.com/sanger-pathogens/gubbins.git \
   && make install \
   && cd python \
   && python3 setup.py install
-  
-# Rename executable for backwards compatibility
-RUN mv /usr/local/bin/run_gubbins.py /usr/local/bin/run_gubbins


### PR DESCRIPTION
Executable should be called 'run_gubbins.py' for consistency, even if that hurts