### PR TITLE
removing mpi option for raxml-ng seems to need separate install

### DIFF
--- a/python/gubbins/treebuilders.py
+++ b/python/gubbins/treebuilders.py
@@ -618,7 +618,7 @@ class RAxMLNG:
         self.additional_args = additional_args
 
         self.single_threaded_executables = ['raxml-ng']
-        self.multi_threaded_executables = ['raxml-ng-mpi','raxml-ng']
+        self.multi_threaded_executables = ['raxml-ng']#['raxml-ng-mpi','raxml-ng'] # Lets remove the mpi version for the moment as this is failing on the cluster
         self.executable = self.select_executable_based_on_threads()
         if self.executable is None:
             sys.exit("No usable version of RAxML-NG could be found.")


### PR DESCRIPTION
- Removing the `raxml-ng-mpi` option for multicore runs 