### PR TITLE
Switch from nosetest -> pytest

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -19,9 +19,8 @@ setuptools.setup(
         'scripts/extract_gubbins_clade.py',
         'scripts/mask_gubbins_aln.py'
     ],
-    test_suite='nose.collector',
     tests_require=[
-        "nose >= 1.3",
+        "pytest >= 4.6",
         "wheel >= 0.34",
         "biopython >= 1.59",
         "dendropy  >= 4.0.2",


### PR DESCRIPTION
Hi,

nose has been deprecated long back, and has not received an update in years, it's official page says so as well, see [here](https://nose.readthedocs.io/en/latest/index.html)
It is adviced to switch to pytest/unittest2/nose2.

This is an attempt to switch to pytest.
Please consider merging.

=====================================================================================

CC: @nickjcroucher 