### PR TITLE
ci: bump github actions versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,9 @@ jobs:
       runs-on: macos-latest
 
       steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.9
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Install dependencies with conda
@@ -25,9 +25,9 @@ jobs:
       runs-on: ubuntu-latest
 
       steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.9
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Install dependencies with conda
@@ -40,6 +40,6 @@ jobs:
         run: |
             source $CONDA/etc/profile.d/conda.sh && conda activate gubbins_env && export LDFLAGS="-L${CONDA_PREFIX}/lib/ -Wl,-rpath,${CONDA_PREFIX}/lib/ --coverage" && export CFLAGS="-I${CONDA_PREFIX}/include/ --coverage" && export PATH=$PATH:/lib/python3.9/site-packages/ && export NUMBA_DISABLE_JIT=1 && autoreconf -i && ./configure --prefix=$CONDA_PREFIX --exec_prefix $CONDA_PREFIX -enable-code-coverage CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" --host=x86_64-linux-gnu --build=x86_64-linux-gnu && make && make install && export CODE_COVERAGE_OUTPUT_FILE="gubbins_coverage.info" && make check && make check-code-coverage
       - name: Upload python code coverage analysis
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
         with:
             files: ./python/coverage.xml,gubbins_coverage.info


### PR DESCRIPTION
Hi @nickjcroucher,

this is my first PR to the project. I did not create an issue first, because the changes proposed are trivial. What do you think?

This PR bumps the versions of the used GitHub Actions, which will get rid of the warnings (e.g. Node.js 16 actions are deprecated. [...] in the [Annotations section under Actions](https://github.com/nickjcroucher/gubbins/actions/runs/8822561800).